### PR TITLE
[bugfix] SpaceTimeCube.data is now maked const...

### DIFF
--- a/src/pyretechnics/space_time_cube.pxd
+++ b/src/pyretechnics/space_time_cube.pxd
@@ -17,7 +17,8 @@ cdef class SpaceTimeCube(ISpaceTimeCube):
     cdef public int t_repetitions
     cdef public int y_repetitions
     cdef public int x_repetitions
-    cdef public float[:,:,:] data
+    # NOTE we use const (read-only MemoryView) so that Cython will accept to use a read-only array, which is required for shared-memory parallelism.
+    cdef public const float[:,:,:] data
     cdef float get(SpaceTimeCube self, pyidx t, pyidx y, pyidx x) noexcept
     # def getTimeSeries(self, t_range, y, x)
     # def getSpatialPlane(self, t, y_range, x_range)

--- a/src/pyretechnics/space_time_cube.py
+++ b/src/pyretechnics/space_time_cube.py
@@ -88,7 +88,7 @@ class SpaceTimeCube(ISpaceTimeCube):
     t_repetitions: cy.int
     y_repetitions: cy.int
     x_repetitions: cy.int
-    data         : cy.float[:,:,:] # FIXME: Restore polymorphism for the underlying Numpy arrays
+    data         : cy.const(cy.float[:,:,:]) # FIXME: Restore polymorphism for the underlying Numpy arrays
 
 
     def __init__(self, cube_shape: tuple[int, int, int], base: object) -> cy.void:


### PR DESCRIPTION
…, allowing it to be used from Ray.

Before this change, trying to initialized the SpaceTimeCube using an array shared through Ray (therefore immutable) would throw an error. Related Cython docs:

https://docs.cython.org/en/latest/src/userguide/memoryviews.html#read-only-views

This change is arguably desirable, because:
1. immutable input arrays are important to enable shared-memory concurrency usage patterns;
2. it would make little sense for Pyretechnics to mutate its input arrays, that's asking for trouble (reminds me of a recent ELMFIRE bug!);
3. it is non-breaking: users could only supply mutable arrays as inputs, now they can also supply immutable arrays.

@lambdatronic.