### PR TITLE
ROS-based crowning checks now account for cc < 0.4.

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -5141,14 +5141,14 @@ intensity and flame length.
 <pre class="src src-python" id="crown-fire-imports"><span class="org-keyword">import</span> cython
 <span class="org-keyword">import</span> cython <span class="org-keyword">as</span> cy
 <span class="org-keyword">if</span> cython.compiled:
-    <span class="org-keyword">from</span> cython.cimports.libc.math <span class="org-keyword">import</span> sqrt, exp, <span class="org-builtin">pow</span>
+    <span class="org-keyword">from</span> cython.cimports.libc.math <span class="org-keyword">import</span> sqrt, exp, <span class="org-builtin">pow</span>, INFINITY <span class="org-keyword">as</span> inf
     <span class="org-keyword">from</span> cython.cimports.pyretechnics.cy_types <span class="org-keyword">import</span> \
         vec_xyz, ProjectedVectors, FireBehaviorMax, SpreadBehavior, CrownSpreadInfo
     <span class="org-keyword">import</span> cython.cimports.pyretechnics.conversion <span class="org-keyword">as</span> conv
     <span class="org-keyword">import</span> cython.cimports.pyretechnics.vector_utils <span class="org-keyword">as</span> vu
     <span class="org-keyword">import</span> cython.cimports.pyretechnics.surface_fire <span class="org-keyword">as</span> sf
 <span class="org-keyword">else</span>:
-    <span class="org-keyword">from</span> math <span class="org-keyword">import</span> sqrt, exp, <span class="org-builtin">pow</span>
+    <span class="org-keyword">from</span> math <span class="org-keyword">import</span> sqrt, exp, <span class="org-builtin">pow</span>, inf
     <span class="org-keyword">from</span> pyretechnics.py_types <span class="org-keyword">import</span> \
         vec_xyz, ProjectedVectors, FireBehaviorMax, SpreadBehavior, CrownSpreadInfo
     <span class="org-keyword">import</span> pyretechnics.conversion <span class="org-keyword">as</span> conv
@@ -5217,21 +5217,29 @@ also calculate the surface fire spread rate at which crowning occurs.
 <span class="org-type">@cy.exceptval</span>(check<span class="org-operator">=</span><span class="org-constant">False</span>)
 <span class="org-keyword">def</span> <span class="org-function-name">van_wagner_crowning_spread_rate</span>(surface_fire_max  : FireBehaviorMax,
                                     canopy_base_height: cy.<span class="org-builtin">float</span>,
-                                    foliar_moisture   : cy.<span class="org-builtin">float</span>) <span class="org-operator">-&gt;</span> cy.<span class="org-builtin">float</span>:
+                                    foliar_moisture   : cy.<span class="org-builtin">float</span>,
+                                    canopy_cover      : cy.<span class="org-builtin">float</span>) <span class="org-operator">-&gt;</span> cy.<span class="org-builtin">float</span>:
     <span class="org-doc">"""</span>
 <span class="org-doc">    Returns the surface spread rate above which crown fire occurs (m/min) given:</span>
 <span class="org-doc">    - surface_fire_max   :: FireBehaviorMax struct</span>
 <span class="org-doc">    - canopy_base_height :: m</span>
 <span class="org-doc">    - foliar_moisture    :: kg moisture/kg ovendry weight</span>
+<span class="org-doc">    - canopy_cover       :: 0-1</span>
+
+<span class="org-doc">    If crowning is not possible (because canopy_cover is too low),</span>
+<span class="org-doc">    returns +inf.</span>
 <span class="org-doc">    """</span>
-    <span class="org-variable-name">surface_max_fireline_intensity</span>: cy.<span class="org-builtin">float</span> <span class="org-operator">=</span> surface_fire_max.max_fireline_intensity
-    <span class="org-keyword">if</span> surface_max_fireline_intensity <span class="org-operator">&gt;</span> 0.0:
-        <span class="org-variable-name">surface_max_spread_rate</span>    : cy.<span class="org-builtin">float</span> <span class="org-operator">=</span> surface_fire_max.max_spread_rate
-        <span class="org-variable-name">critical_fireline_intensity</span>: cy.<span class="org-builtin">float</span> <span class="org-operator">=</span> van_wagner_critical_fireline_intensity(canopy_base_height,
-                                                                                       foliar_moisture)
-        <span class="org-keyword">return</span> (surface_max_spread_rate <span class="org-operator">*</span> critical_fireline_intensity <span class="org-operator">/</span> surface_max_fireline_intensity)
+    <span class="org-keyword">if</span> canopy_cover <span class="org-operator">&lt;=</span> 0.4:
+        <span class="org-keyword">return</span> inf
     <span class="org-keyword">else</span>:
-        <span class="org-keyword">return</span> 0.0
+        <span class="org-variable-name">surface_max_fireline_intensity</span>: cy.<span class="org-builtin">float</span> <span class="org-operator">=</span> surface_fire_max.max_fireline_intensity
+        <span class="org-keyword">if</span> surface_max_fireline_intensity <span class="org-operator">&gt;</span> 0.0:
+            <span class="org-variable-name">surface_max_spread_rate</span>    : cy.<span class="org-builtin">float</span> <span class="org-operator">=</span> surface_fire_max.max_spread_rate
+            <span class="org-variable-name">critical_fireline_intensity</span>: cy.<span class="org-builtin">float</span> <span class="org-operator">=</span> van_wagner_critical_fireline_intensity(canopy_base_height,
+                                                                                           foliar_moisture)
+            <span class="org-keyword">return</span> (surface_max_spread_rate <span class="org-operator">*</span> critical_fireline_intensity <span class="org-operator">/</span> surface_max_fireline_intensity)
+        <span class="org-keyword">else</span>:
+            <span class="org-keyword">return</span> 0.0
 </pre>
 </div>
 
@@ -9689,7 +9697,7 @@ model<sup><a id="fnr.38.100" class="footref" href="#fn.38" role="doc-backlink">3
 <span class="org-keyword">if</span> cython.compiled:
     <span class="org-keyword">from</span> cython.cimports.numpy <span class="org-keyword">import</span> ndarray
     <span class="org-keyword">from</span> cython.cimports.libc.stdlib <span class="org-keyword">import</span> malloc, realloc, free
-    <span class="org-keyword">from</span> cython.cimports.libc.math <span class="org-keyword">import</span> pi, floor, sqrt, <span class="org-builtin">pow</span>, atan
+    <span class="org-keyword">from</span> cython.cimports.libc.math <span class="org-keyword">import</span> pi, floor, sqrt, <span class="org-builtin">pow</span>, atan, INFINITY <span class="org-keyword">as</span> inf, isinf
     <span class="org-keyword">from</span> cython.cimports.pyretechnics.cy_types <span class="org-keyword">import</span> pyidx, vec_xy, vec_xyz, coord_yx, coord_tyx, \
         fclaarr, FuelModel, FireBehaviorMin, FireBehaviorMax, SpreadBehavior, SpotConfig, \
         PartialedEllWavelet, CellInputs, EllipticalInfo, Pass1CellOutput
@@ -9706,7 +9714,7 @@ model<sup><a id="fnr.38.100" class="footref" href="#fn.38" role="doc-backlink">3
 <span class="org-keyword">else</span>:
     <span class="org-comment-delimiter"># </span><span class="org-comment">TODO: Create equivalent Python functions for malloc, realloc, free</span>
     <span class="org-keyword">from</span> numpy <span class="org-keyword">import</span> ndarray
-    <span class="org-keyword">from</span> math <span class="org-keyword">import</span> pi, floor, sqrt, <span class="org-builtin">pow</span>, atan
+    <span class="org-keyword">from</span> math <span class="org-keyword">import</span> pi, floor, sqrt, <span class="org-builtin">pow</span>, atan, inf, isinf
     <span class="org-keyword">from</span> pyretechnics.py_types <span class="org-keyword">import</span> pyidx, vec_xy, vec_xyz, coord_yx, coord_tyx, \
         fclaarr, FuelModel, FireBehaviorMin, FireBehaviorMax, SpreadBehavior, SpotConfig, \
         PartialedEllWavelet, CellInputs, EllipticalInfo, Pass1CellOutput
@@ -11440,7 +11448,11 @@ $ \bar{U}_x = - \frac{d \varphi}{dt} \frac{1}{|\nabla \varphi|^2}  \frac{\partia
 <span class="org-doc">    Logically equivalent to: (surface_spread_rate &gt; crowning_spread_rate)</span>
 <span class="org-doc">    but faster to compute and robust to zero phi gradient.</span>
 <span class="org-doc">    """</span>
-    <span class="org-keyword">return</span> (surface_dphi_dt <span class="org-operator">*</span> surface_dphi_dt) <span class="org-operator">&gt;</span> (crowning_spread_rate <span class="org-operator">*</span> crowning_spread_rate <span class="org-operator">*</span> phi_magnitude_xyz_2)
+    <span class="org-comment-delimiter"># </span><span class="org-comment">If crowning_spread_rate is +inf, it means that crowning is not possible.</span>
+    <span class="org-keyword">if</span> isinf(crowning_spread_rate):
+        <span class="org-keyword">return</span> <span class="org-constant">False</span>
+    <span class="org-keyword">else</span>:
+        <span class="org-keyword">return</span> (surface_dphi_dt <span class="org-operator">*</span> surface_dphi_dt) <span class="org-operator">&gt;</span> (crowning_spread_rate <span class="org-operator">*</span> crowning_spread_rate <span class="org-operator">*</span> phi_magnitude_xyz_2)
 
 
 <span class="org-comment-delimiter"># </span><span class="org-comment">NOTE: Changing this function to accept a pointer to an EllipticalInfo did not yield appreciable performance gains.</span>
@@ -12016,7 +12028,8 @@ $ \bar{U}_x = - \frac{d \varphi}{dt} \frac{1}{|\nabla \varphi|^2}  \frac{\partia
 <span class="org-doc">    """</span>
     <span class="org-keyword">return</span> cf.van_wagner_crowning_spread_rate(surface_fire_max,
                                               cell_inputs.canopy_base_height,
-                                              cell_inputs.foliar_moisture)
+                                              cell_inputs.foliar_moisture,
+                                              cell_inputs.canopy_cover)
 
 
 <span class="org-type">@cy.cfunc</span>
@@ -12036,7 +12049,7 @@ $ \bar{U}_x = - \frac{d \varphi}{dt} \frac{1}{|\nabla \varphi|^2}  \frac{\partia
     <span class="org-keyword">if</span> <span class="org-keyword">not</span> fuel_model.burnable:
         <span class="org-variable-name">surface_wavelet</span>      <span class="org-operator">=</span> zero_partialed_wavelet()
         <span class="org-variable-name">crown_wavelet</span>        <span class="org-operator">=</span> zero_partialed_wavelet()
-        <span class="org-variable-name">crowning_spread_rate</span> <span class="org-operator">=</span> 1234.5 <span class="org-comment-delimiter"># </span><span class="org-comment">arbitrary positive value - this threshold will never be reached.</span>
+        <span class="org-variable-name">crowning_spread_rate</span> <span class="org-operator">=</span> inf <span class="org-comment-delimiter"># </span><span class="org-comment">crowning is not possible</span>
     <span class="org-keyword">else</span>:
         <span class="org-variable-name">surface_fire_max</span>: FireBehaviorMax <span class="org-operator">=</span> resolve_surface_max_behavior(fb_opts,
                                                                          cell_inputs,
@@ -19040,6 +19053,7 @@ cdef <span class="org-builtin">float</span> van_wagner_crowning_spread_rate(
     FireBehaviorMax surface_fire_max,
     <span class="org-builtin">float</span> canopy_base_height,
     <span class="org-builtin">float</span> foliar_moisture,
+    <span class="org-builtin">float</span> canopy_cover,
     ) noexcept
 
 cpdef bint van_wagner_crown_fire_initiation(

--- a/org/pyretechnics.org
+++ b/org/pyretechnics.org
@@ -4575,7 +4575,7 @@ def van_wagner_crowning_spread_rate(surface_fire_max  : FireBehaviorMax,
         if surface_max_fireline_intensity > 0.0:
             surface_max_spread_rate    : cy.float = surface_fire_max.max_spread_rate
             critical_fireline_intensity: cy.float = van_wagner_critical_fireline_intensity(canopy_base_height,
-                                                                                        foliar_moisture)
+                                                                                           foliar_moisture)
             return (surface_max_spread_rate * critical_fireline_intensity / surface_max_fireline_intensity)
         else:
             return 0.0
@@ -10422,7 +10422,8 @@ def phi_aware_crowning_check(phi_magnitude_xyz_2 : cy.float,
     # If crowning_spread_rate is +inf, it means that crowning is not possible.
     if isinf(crowning_spread_rate):
         return False
-    return (surface_dphi_dt * surface_dphi_dt) > (crowning_spread_rate * crowning_spread_rate * phi_magnitude_xyz_2)
+    else:
+        return (surface_dphi_dt * surface_dphi_dt) > (crowning_spread_rate * crowning_spread_rate * phi_magnitude_xyz_2)
 
 
 # NOTE: Changing this function to accept a pointer to an EllipticalInfo did not yield appreciable performance gains.

--- a/org/pyretechnics.org
+++ b/org/pyretechnics.org
@@ -4570,14 +4570,15 @@ def van_wagner_crowning_spread_rate(surface_fire_max  : FireBehaviorMax,
     """
     if canopy_cover <= 0.4:
         return inf
-    surface_max_fireline_intensity: cy.float = surface_fire_max.max_fireline_intensity
-    if surface_max_fireline_intensity > 0.0:
-        surface_max_spread_rate    : cy.float = surface_fire_max.max_spread_rate
-        critical_fireline_intensity: cy.float = van_wagner_critical_fireline_intensity(canopy_base_height,
-                                                                                       foliar_moisture)
-        return (surface_max_spread_rate * critical_fireline_intensity / surface_max_fireline_intensity)
     else:
-        return 0.0
+        surface_max_fireline_intensity: cy.float = surface_fire_max.max_fireline_intensity
+        if surface_max_fireline_intensity > 0.0:
+            surface_max_spread_rate    : cy.float = surface_fire_max.max_spread_rate
+            critical_fireline_intensity: cy.float = van_wagner_critical_fireline_intensity(canopy_base_height,
+                                                                                        foliar_moisture)
+            return (surface_max_spread_rate * critical_fireline_intensity / surface_max_fireline_intensity)
+        else:
+            return 0.0
 #+end_src
 
 If a surface fire is present, the canopy cover is greater than 40%,
@@ -10411,26 +10412,11 @@ def dphi_dt_from_partialed_wavelet(wavelet            : PartialedEllWavelet,
 @cy.cfunc
 @cy.inline
 @cy.exceptval(check=False)
-def ros_crowning_check(crowning_spread_rate: cy.float, front_normal_spread_rate: cy.float) -> cy.bint:
-    """
-    Checks whether crowning occurs, based on spread rate.
-
-    crowning_spread_rate is the one computed by function `crown_fire_spread_rate()`,
-    and may be +inf to signal that crowning is not possible.
-    """
-    if isinf(crowning_spread_rate):
-        return False
-    return front_normal_spread_rate > crowning_spread_rate
-
-
-@cy.cfunc
-@cy.inline
-@cy.exceptval(check=False)
 def phi_aware_crowning_check(phi_magnitude_xyz_2 : cy.float,
                              surface_dphi_dt     : cy.float,
                              crowning_spread_rate: cy.float) -> cy.bint:
     """
-    Logically equivalent to ros_crowning_check(),
+    Logically equivalent to: (surface_spread_rate > crowning_spread_rate)
     but faster to compute and robust to zero phi gradient.
     """
     # If crowning_spread_rate is +inf, it means that crowning is not possible.
@@ -11125,7 +11111,7 @@ def resolve_combined_spread_behavior(spread_inputs        : SpreadInputs,
                                                                                               spread_direction)
         # Check whether a crown fire occurs
         crowning_spread_rate: cy.float = resolve_crowning_spread_rate(cell_inputs, surface_fire_max)
-        if not ros_crowning_check(crowning_spread_rate, surface_fire_max_simple.spread_rate):
+        if (surface_fire_max_simple.spread_rate <= crowning_spread_rate):
             return surface_fire_max_simple
         else:
             crown_fire_max       : FireBehaviorMax = resolve_crown_max_behavior(fb_opts, cell_inputs, fuel_model)
@@ -11145,7 +11131,7 @@ def resolve_combined_spread_behavior(spread_inputs        : SpreadInputs,
         surface_fire_normal: SpreadBehavior  = calc_fireline_normal_behavior(surface_fire_max, phi_gradient_xyz)
         # Check whether a crown fire occurs
         crowning_spread_rate: cy.float = resolve_crowning_spread_rate(cell_inputs, surface_fire_max)
-        if not ros_crowning_check(crowning_spread_rate, surface_fire_normal.spread_rate):
+        if (surface_fire_normal.spread_rate <= crowning_spread_rate):
             return surface_fire_normal
         else:
             crown_fire_max      : FireBehaviorMax = resolve_crown_max_behavior(fb_opts, cell_inputs, fuel_model)

--- a/org/pyretechnics.org
+++ b/org/pyretechnics.org
@@ -4486,14 +4486,14 @@ intensity and flame length.
 import cython
 import cython as cy
 if cython.compiled:
-    from cython.cimports.libc.math import sqrt, exp, pow
+    from cython.cimports.libc.math import sqrt, exp, pow, INFINITY as inf
     from cython.cimports.pyretechnics.cy_types import \
         vec_xyz, ProjectedVectors, FireBehaviorMax, SpreadBehavior, CrownSpreadInfo
     import cython.cimports.pyretechnics.conversion as conv
     import cython.cimports.pyretechnics.vector_utils as vu
     import cython.cimports.pyretechnics.surface_fire as sf
 else:
-    from math import sqrt, exp, pow
+    from math import sqrt, exp, pow, inf
     from pyretechnics.py_types import \
         vec_xyz, ProjectedVectors, FireBehaviorMax, SpreadBehavior, CrownSpreadInfo
     import pyretechnics.conversion as conv
@@ -4556,13 +4556,20 @@ also calculate the surface fire spread rate at which crowning occurs.
 @cy.exceptval(check=False)
 def van_wagner_crowning_spread_rate(surface_fire_max  : FireBehaviorMax,
                                     canopy_base_height: cy.float,
-                                    foliar_moisture   : cy.float) -> cy.float:
+                                    foliar_moisture   : cy.float,
+                                    canopy_cover      : cy.float) -> cy.float:
     """
     Returns the surface spread rate above which crown fire occurs (m/min) given:
     - surface_fire_max   :: FireBehaviorMax struct
     - canopy_base_height :: m
     - foliar_moisture    :: kg moisture/kg ovendry weight
+    - canopy_cover       :: 0-1
+
+    If crowning is not possible (because canopy_cover is too low),
+    returns +inf.
     """
+    if canopy_cover <= 0.4:
+        return inf
     surface_max_fireline_intensity: cy.float = surface_fire_max.max_fireline_intensity
     if surface_max_fireline_intensity > 0.0:
         surface_max_spread_rate    : cy.float = surface_fire_max.max_spread_rate
@@ -8711,7 +8718,7 @@ from sortedcontainers import SortedDict
 if cython.compiled:
     from cython.cimports.numpy import ndarray
     from cython.cimports.libc.stdlib import malloc, realloc, free
-    from cython.cimports.libc.math import pi, floor, sqrt, pow, atan
+    from cython.cimports.libc.math import pi, floor, sqrt, pow, atan, INFINITY as inf, isinf
     from cython.cimports.pyretechnics.cy_types import pyidx, vec_xy, vec_xyz, coord_yx, coord_tyx, \
         fclaarr, FuelModel, FireBehaviorMin, FireBehaviorMax, SpreadBehavior, SpotConfig, \
         PartialedEllWavelet, CellInputs, EllipticalInfo, Pass1CellOutput
@@ -8728,7 +8735,7 @@ if cython.compiled:
 else:
     # TODO: Create equivalent Python functions for malloc, realloc, free
     from numpy import ndarray
-    from math import pi, floor, sqrt, pow, atan
+    from math import pi, floor, sqrt, pow, atan, inf, isinf
     from pyretechnics.py_types import pyidx, vec_xy, vec_xyz, coord_yx, coord_tyx, \
         fclaarr, FuelModel, FireBehaviorMin, FireBehaviorMax, SpreadBehavior, SpotConfig, \
         PartialedEllWavelet, CellInputs, EllipticalInfo, Pass1CellOutput
@@ -10404,13 +10411,31 @@ def dphi_dt_from_partialed_wavelet(wavelet            : PartialedEllWavelet,
 @cy.cfunc
 @cy.inline
 @cy.exceptval(check=False)
+def ros_crowning_check(crowning_spread_rate: cy.float, front_normal_spread_rate: cy.float) -> cy.bint:
+    """
+    Checks whether crowning occurs, based on spread rate.
+
+    crowning_spread_rate is the one computed by function `crown_fire_spread_rate()`,
+    and may be +inf to signal that crowning is not possible.
+    """
+    if isinf(crowning_spread_rate):
+        return False
+    return front_normal_spread_rate > crowning_spread_rate
+
+
+@cy.cfunc
+@cy.inline
+@cy.exceptval(check=False)
 def phi_aware_crowning_check(phi_magnitude_xyz_2 : cy.float,
                              surface_dphi_dt     : cy.float,
                              crowning_spread_rate: cy.float) -> cy.bint:
     """
-    Logically equivalent to: (surface_spread_rate > crowning_spread_rate)
+    Logically equivalent to ros_crowning_check(),
     but faster to compute and robust to zero phi gradient.
     """
+    # If crowning_spread_rate is +inf, it means that crowning is not possible.
+    if isinf(crowning_spread_rate):
+        return False
     return (surface_dphi_dt * surface_dphi_dt) > (crowning_spread_rate * crowning_spread_rate * phi_magnitude_xyz_2)
 
 
@@ -10987,7 +11012,8 @@ def resolve_crowning_spread_rate(cell_inputs: CellInputs, surface_fire_max: Fire
     """
     return cf.van_wagner_crowning_spread_rate(surface_fire_max,
                                               cell_inputs.canopy_base_height,
-                                              cell_inputs.foliar_moisture)
+                                              cell_inputs.foliar_moisture,
+                                              cell_inputs.canopy_cover)
 
 
 @cy.cfunc
@@ -11007,7 +11033,7 @@ def resolve_cell_elliptical_info(fb_opts         : FireBehaviorSettings,
     if not fuel_model.burnable:
         surface_wavelet      = zero_partialed_wavelet()
         crown_wavelet        = zero_partialed_wavelet()
-        crowning_spread_rate = 1234.5 # arbitrary positive value - this threshold will never be reached.
+        crowning_spread_rate = inf # crowning is not possible
     else:
         surface_fire_max: FireBehaviorMax = resolve_surface_max_behavior(fb_opts,
                                                                          cell_inputs,
@@ -11099,7 +11125,7 @@ def resolve_combined_spread_behavior(spread_inputs        : SpreadInputs,
                                                                                               spread_direction)
         # Check whether a crown fire occurs
         crowning_spread_rate: cy.float = resolve_crowning_spread_rate(cell_inputs, surface_fire_max)
-        if (surface_fire_max_simple.spread_rate <= crowning_spread_rate):
+        if not ros_crowning_check(crowning_spread_rate, surface_fire_max_simple.spread_rate):
             return surface_fire_max_simple
         else:
             crown_fire_max       : FireBehaviorMax = resolve_crown_max_behavior(fb_opts, cell_inputs, fuel_model)
@@ -11119,7 +11145,7 @@ def resolve_combined_spread_behavior(spread_inputs        : SpreadInputs,
         surface_fire_normal: SpreadBehavior  = calc_fireline_normal_behavior(surface_fire_max, phi_gradient_xyz)
         # Check whether a crown fire occurs
         crowning_spread_rate: cy.float = resolve_crowning_spread_rate(cell_inputs, surface_fire_max)
-        if (surface_fire_normal.spread_rate <= crowning_spread_rate):
+        if not ros_crowning_check(crowning_spread_rate, surface_fire_normal.spread_rate):
             return surface_fire_normal
         else:
             crown_fire_max      : FireBehaviorMax = resolve_crown_max_behavior(fb_opts, cell_inputs, fuel_model)
@@ -18006,6 +18032,7 @@ cdef float van_wagner_crowning_spread_rate(
     FireBehaviorMax surface_fire_max,
     float canopy_base_height,
     float foliar_moisture,
+    float canopy_cover,
     ) noexcept
 
 cpdef bint van_wagner_crown_fire_initiation(

--- a/src/pyretechnics/crown_fire.pxd
+++ b/src/pyretechnics/crown_fire.pxd
@@ -10,6 +10,7 @@ cdef float van_wagner_crowning_spread_rate(
     FireBehaviorMax surface_fire_max,
     float canopy_base_height,
     float foliar_moisture,
+    float canopy_cover,
     ) noexcept
 
 cpdef bint van_wagner_crown_fire_initiation(

--- a/src/pyretechnics/crown_fire.py
+++ b/src/pyretechnics/crown_fire.py
@@ -2,14 +2,14 @@
 import cython
 import cython as cy
 if cython.compiled:
-    from cython.cimports.libc.math import sqrt, exp, pow
+    from cython.cimports.libc.math import sqrt, exp, pow, INFINITY as inf
     from cython.cimports.pyretechnics.cy_types import \
         vec_xyz, ProjectedVectors, FireBehaviorMax, SpreadBehavior, CrownSpreadInfo
     import cython.cimports.pyretechnics.conversion as conv
     import cython.cimports.pyretechnics.vector_utils as vu
     import cython.cimports.pyretechnics.surface_fire as sf
 else:
-    from math import sqrt, exp, pow
+    from math import sqrt, exp, pow, inf
     from pyretechnics.py_types import \
         vec_xyz, ProjectedVectors, FireBehaviorMax, SpreadBehavior, CrownSpreadInfo
     import pyretechnics.conversion as conv
@@ -38,13 +38,20 @@ def van_wagner_critical_fireline_intensity(canopy_base_height: cy.float, foliar_
 @cy.exceptval(check=False)
 def van_wagner_crowning_spread_rate(surface_fire_max  : FireBehaviorMax,
                                     canopy_base_height: cy.float,
-                                    foliar_moisture   : cy.float) -> cy.float:
+                                    foliar_moisture   : cy.float,
+                                    canopy_cover      : cy.float) -> cy.float:
     """
     Returns the surface spread rate above which crown fire occurs (m/min) given:
     - surface_fire_max   :: FireBehaviorMax struct
     - canopy_base_height :: m
     - foliar_moisture    :: kg moisture/kg ovendry weight
+    - canopy_cover       :: 0-1
+
+    If crowning is not possible (because canopy_cover is too low),
+    returns +inf.
     """
+    if canopy_cover <= 0.4:
+        return inf
     surface_max_fireline_intensity: cy.float = surface_fire_max.max_fireline_intensity
     if surface_max_fireline_intensity > 0.0:
         surface_max_spread_rate    : cy.float = surface_fire_max.max_spread_rate

--- a/src/pyretechnics/crown_fire.py
+++ b/src/pyretechnics/crown_fire.py
@@ -52,14 +52,15 @@ def van_wagner_crowning_spread_rate(surface_fire_max  : FireBehaviorMax,
     """
     if canopy_cover <= 0.4:
         return inf
-    surface_max_fireline_intensity: cy.float = surface_fire_max.max_fireline_intensity
-    if surface_max_fireline_intensity > 0.0:
-        surface_max_spread_rate    : cy.float = surface_fire_max.max_spread_rate
-        critical_fireline_intensity: cy.float = van_wagner_critical_fireline_intensity(canopy_base_height,
-                                                                                       foliar_moisture)
-        return (surface_max_spread_rate * critical_fireline_intensity / surface_max_fireline_intensity)
     else:
-        return 0.0
+        surface_max_fireline_intensity: cy.float = surface_fire_max.max_fireline_intensity
+        if surface_max_fireline_intensity > 0.0:
+            surface_max_spread_rate    : cy.float = surface_fire_max.max_spread_rate
+            critical_fireline_intensity: cy.float = van_wagner_critical_fireline_intensity(canopy_base_height,
+                                                                                        foliar_moisture)
+            return (surface_max_spread_rate * critical_fireline_intensity / surface_max_fireline_intensity)
+        else:
+            return 0.0
 # van-wagner-crowning-spread-rate ends here
 # [[file:../../org/pyretechnics.org::van-wagner-crown-fire-initiation][van-wagner-crown-fire-initiation]]
 @cy.ccall

--- a/src/pyretechnics/crown_fire.py
+++ b/src/pyretechnics/crown_fire.py
@@ -57,7 +57,7 @@ def van_wagner_crowning_spread_rate(surface_fire_max  : FireBehaviorMax,
         if surface_max_fireline_intensity > 0.0:
             surface_max_spread_rate    : cy.float = surface_fire_max.max_spread_rate
             critical_fireline_intensity: cy.float = van_wagner_critical_fireline_intensity(canopy_base_height,
-                                                                                        foliar_moisture)
+                                                                                           foliar_moisture)
             return (surface_max_spread_rate * critical_fireline_intensity / surface_max_fireline_intensity)
         else:
             return 0.0

--- a/src/pyretechnics/eulerian_level_set.py
+++ b/src/pyretechnics/eulerian_level_set.py
@@ -1365,26 +1365,11 @@ def dphi_dt_from_partialed_wavelet(wavelet            : PartialedEllWavelet,
 @cy.cfunc
 @cy.inline
 @cy.exceptval(check=False)
-def ros_crowning_check(crowning_spread_rate: cy.float, front_normal_spread_rate: cy.float) -> cy.bint:
-    """
-    Checks whether crowning occurs, based on spread rate.
-
-    crowning_spread_rate is the one computed by function `crown_fire_spread_rate()`,
-    and may be +inf to signal that crowning is not possible.
-    """
-    if isinf(crowning_spread_rate):
-        return False
-    return front_normal_spread_rate > crowning_spread_rate
-
-
-@cy.cfunc
-@cy.inline
-@cy.exceptval(check=False)
 def phi_aware_crowning_check(phi_magnitude_xyz_2 : cy.float,
                              surface_dphi_dt     : cy.float,
                              crowning_spread_rate: cy.float) -> cy.bint:
     """
-    Logically equivalent to ros_crowning_check(),
+    Logically equivalent to: (surface_spread_rate > crowning_spread_rate)
     but faster to compute and robust to zero phi gradient.
     """
     # If crowning_spread_rate is +inf, it means that crowning is not possible.
@@ -2079,7 +2064,7 @@ def resolve_combined_spread_behavior(spread_inputs        : SpreadInputs,
                                                                                               spread_direction)
         # Check whether a crown fire occurs
         crowning_spread_rate: cy.float = resolve_crowning_spread_rate(cell_inputs, surface_fire_max)
-        if not ros_crowning_check(crowning_spread_rate, surface_fire_max_simple.spread_rate):
+        if (surface_fire_max_simple.spread_rate <= crowning_spread_rate):
             return surface_fire_max_simple
         else:
             crown_fire_max       : FireBehaviorMax = resolve_crown_max_behavior(fb_opts, cell_inputs, fuel_model)
@@ -2099,7 +2084,7 @@ def resolve_combined_spread_behavior(spread_inputs        : SpreadInputs,
         surface_fire_normal: SpreadBehavior  = calc_fireline_normal_behavior(surface_fire_max, phi_gradient_xyz)
         # Check whether a crown fire occurs
         crowning_spread_rate: cy.float = resolve_crowning_spread_rate(cell_inputs, surface_fire_max)
-        if not ros_crowning_check(crowning_spread_rate, surface_fire_normal.spread_rate):
+        if (surface_fire_normal.spread_rate <= crowning_spread_rate):
             return surface_fire_normal
         else:
             crown_fire_max      : FireBehaviorMax = resolve_crown_max_behavior(fb_opts, cell_inputs, fuel_model)

--- a/src/pyretechnics/eulerian_level_set.py
+++ b/src/pyretechnics/eulerian_level_set.py
@@ -7,7 +7,7 @@ from sortedcontainers import SortedDict
 if cython.compiled:
     from cython.cimports.numpy import ndarray
     from cython.cimports.libc.stdlib import malloc, realloc, free
-    from cython.cimports.libc.math import pi, floor, sqrt, pow, atan
+    from cython.cimports.libc.math import pi, floor, sqrt, pow, atan, INFINITY as inf, isinf
     from cython.cimports.pyretechnics.cy_types import pyidx, vec_xy, vec_xyz, coord_yx, coord_tyx, \
         fclaarr, FuelModel, FireBehaviorMin, FireBehaviorMax, SpreadBehavior, SpotConfig, \
         PartialedEllWavelet, CellInputs, EllipticalInfo, Pass1CellOutput
@@ -24,7 +24,7 @@ if cython.compiled:
 else:
     # TODO: Create equivalent Python functions for malloc, realloc, free
     from numpy import ndarray
-    from math import pi, floor, sqrt, pow, atan
+    from math import pi, floor, sqrt, pow, atan, inf, isinf
     from pyretechnics.py_types import pyidx, vec_xy, vec_xyz, coord_yx, coord_tyx, \
         fclaarr, FuelModel, FireBehaviorMin, FireBehaviorMax, SpreadBehavior, SpotConfig, \
         PartialedEllWavelet, CellInputs, EllipticalInfo, Pass1CellOutput
@@ -1365,13 +1365,31 @@ def dphi_dt_from_partialed_wavelet(wavelet            : PartialedEllWavelet,
 @cy.cfunc
 @cy.inline
 @cy.exceptval(check=False)
+def ros_crowning_check(crowning_spread_rate: cy.float, front_normal_spread_rate: cy.float) -> cy.bint:
+    """
+    Checks whether crowning occurs, based on spread rate.
+
+    crowning_spread_rate is the one computed by function `crown_fire_spread_rate()`,
+    and may be +inf to signal that crowning is not possible.
+    """
+    if isinf(crowning_spread_rate):
+        return False
+    return front_normal_spread_rate > crowning_spread_rate
+
+
+@cy.cfunc
+@cy.inline
+@cy.exceptval(check=False)
 def phi_aware_crowning_check(phi_magnitude_xyz_2 : cy.float,
                              surface_dphi_dt     : cy.float,
                              crowning_spread_rate: cy.float) -> cy.bint:
     """
-    Logically equivalent to: (surface_spread_rate > crowning_spread_rate)
+    Logically equivalent to ros_crowning_check(),
     but faster to compute and robust to zero phi gradient.
     """
+    # If crowning_spread_rate is +inf, it means that crowning is not possible.
+    if isinf(crowning_spread_rate):
+        return False
     return (surface_dphi_dt * surface_dphi_dt) > (crowning_spread_rate * crowning_spread_rate * phi_magnitude_xyz_2)
 
 
@@ -1948,7 +1966,8 @@ def resolve_crowning_spread_rate(cell_inputs: CellInputs, surface_fire_max: Fire
     """
     return cf.van_wagner_crowning_spread_rate(surface_fire_max,
                                               cell_inputs.canopy_base_height,
-                                              cell_inputs.foliar_moisture)
+                                              cell_inputs.foliar_moisture,
+                                              cell_inputs.canopy_cover)
 
 
 @cy.cfunc
@@ -1968,7 +1987,7 @@ def resolve_cell_elliptical_info(fb_opts         : FireBehaviorSettings,
     if not fuel_model.burnable:
         surface_wavelet      = zero_partialed_wavelet()
         crown_wavelet        = zero_partialed_wavelet()
-        crowning_spread_rate = 1234.5 # arbitrary positive value - this threshold will never be reached.
+        crowning_spread_rate = inf # crowning is not possible
     else:
         surface_fire_max: FireBehaviorMax = resolve_surface_max_behavior(fb_opts,
                                                                          cell_inputs,
@@ -2060,7 +2079,7 @@ def resolve_combined_spread_behavior(spread_inputs        : SpreadInputs,
                                                                                               spread_direction)
         # Check whether a crown fire occurs
         crowning_spread_rate: cy.float = resolve_crowning_spread_rate(cell_inputs, surface_fire_max)
-        if (surface_fire_max_simple.spread_rate <= crowning_spread_rate):
+        if not ros_crowning_check(crowning_spread_rate, surface_fire_max_simple.spread_rate):
             return surface_fire_max_simple
         else:
             crown_fire_max       : FireBehaviorMax = resolve_crown_max_behavior(fb_opts, cell_inputs, fuel_model)
@@ -2080,7 +2099,7 @@ def resolve_combined_spread_behavior(spread_inputs        : SpreadInputs,
         surface_fire_normal: SpreadBehavior  = calc_fireline_normal_behavior(surface_fire_max, phi_gradient_xyz)
         # Check whether a crown fire occurs
         crowning_spread_rate: cy.float = resolve_crowning_spread_rate(cell_inputs, surface_fire_max)
-        if (surface_fire_normal.spread_rate <= crowning_spread_rate):
+        if not ros_crowning_check(crowning_spread_rate, surface_fire_normal.spread_rate):
             return surface_fire_normal
         else:
             crown_fire_max      : FireBehaviorMax = resolve_crown_max_behavior(fb_opts, cell_inputs, fuel_model)

--- a/src/pyretechnics/eulerian_level_set.py
+++ b/src/pyretechnics/eulerian_level_set.py
@@ -1375,7 +1375,8 @@ def phi_aware_crowning_check(phi_magnitude_xyz_2 : cy.float,
     # If crowning_spread_rate is +inf, it means that crowning is not possible.
     if isinf(crowning_spread_rate):
         return False
-    return (surface_dphi_dt * surface_dphi_dt) > (crowning_spread_rate * crowning_spread_rate * phi_magnitude_xyz_2)
+    else:
+        return (surface_dphi_dt * surface_dphi_dt) > (crowning_spread_rate * crowning_spread_rate * phi_magnitude_xyz_2)
 
 
 # NOTE: Changing this function to accept a pointer to an EllipticalInfo did not yield appreciable performance gains.


### PR DESCRIPTION
It's not trivial to do this without degrading the memory footprint or disrupting the code structure. For this reason, 'crowning impossible' is encoded as an infinite spread rate threshold. This was tested on example fires.